### PR TITLE
docs: fix typo in Open Source Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Whether you are a beginner eager to explore or an experienced professional seeki
 - **Hands-on Python Coding**: Learn to code with Python in a way that's directly applicable to real-world AI projects.
 - **Project-Driven Learning**: Each chapter includes practical project instructions to help you apply what you've learned.
 - **MLOps Techniques**: Gain insights into effective MLOps coding strategies that streamline the development and deployment of AI/ML models.
-- **Open Source Tools**: Familiarize yourself with industry-standard tools like [uv](https://docs.astral.sh/uv/), [pytest](https://docs.pytest.org/en/latest/),/mlflow.org/), [bandit](https://bandit.readthedocs.io/en/latest/), [pre-commit](https://pre-commit.com/), [GitHub](https://github.com/), and [VS Code](https://code.visualstudio.com/).
+- **Open Source Tools**: Familiarize yourself with industry-standard tools like [uv](https://docs.astral.sh/uv/), [pytest](https://docs.pytest.org/en/latest/), [MLflow](https://mlflow.org/), [bandit](https://bandit.readthedocs.io/en/latest/), [pre-commit](https://pre-commit.com/), [GitHub](https://github.com/), and [VS Code](https://code.visualstudio.com/).
 - **Mentoring sessions**: Boost your learning experience with personalized feedback and expert insights from the course authors.
   - Book [a one-on-one mentoring session](https://calendar.app.google/9KfEBkpCHQKwarLF8) to receive tailored guidance and support on the course.
   - Contact the [course creators](mailto:mlops-coding-course@fmind.dev) to request a personalized quote for group and organization training.


### PR DESCRIPTION
This pull request makes a small correction to the list of open source tools in the `README.md` file. The change fixes the link and name for MLflow, ensuring it is correctly referenced as `[MLflow](https://mlflow.org/)`.