### PR TITLE
Fix 4 dead neptune.ai blog links across course docs

### DIFF
--- a/docs/1. Initializing/1.0. System.md
+++ b/docs/1. Initializing/1.0. System.md
@@ -49,4 +49,4 @@ When using cloud services, be mindful of resource management and usage quotas, p
 
 - [GitHub Codespaces](https://github.com/features/codespaces)
 - [Google Cloud Workstations](https://cloud.google.com/workstations)
-- [MLOps Landscape in 2024: Top Tools and Platforms](https://neptune.ai/blog/mlops-tools-platforms-landscape)
+- [MLOps Landscape in 2024: Top Tools and Platforms](https://web.archive.org/web/20251006160541/https://neptune.ai/blog/mlops-tools-platforms-landscape)

--- a/docs/5. Refining/5.5. AI-ML Experiments.md
+++ b/docs/5. Refining/5.5. AI-ML Experiments.md
@@ -8,7 +8,7 @@ description: Master AI/ML experiment tracking with MLflow. Learn how to effectiv
 
 ## What is an AI/ML experiment?
 
-[An AI/ML experiment](https://neptune.ai/blog/ml-experiment-tracking) is a systematic and iterative process for building robust machine learning models. It involves testing different algorithms, tuning hyperparameters, and using various datasets to discover the optimal configuration for a specific predictive task. Each experiment is a structured trial designed to measure the impact of changes on model performance, such as accuracy, efficiency, and reliability.
+[An AI/ML experiment](https://www.bestaiweb.ai/glossary/experiment-tracking/) is a systematic and iterative process for building robust machine learning models. It involves testing different algorithms, tuning hyperparameters, and using various datasets to discover the optimal configuration for a specific predictive task. Each experiment is a structured trial designed to measure the impact of changes on model performance, such as accuracy, efficiency, and reliability.
 
 ## Why is experiment tracking essential in AI/ML?
 

--- a/docs/5. Refining/5.6. Model Registries.md
+++ b/docs/5. Refining/5.6. Model Registries.md
@@ -8,7 +8,7 @@ description: Explore the use of model registries with MLflow for managing model 
 
 ## What is a model registry?
 
-[A model registry](https://neptune.ai/blog/ml-model-registry) is a centralized repository designed to manage the lifecycle of machine learning models. It acts as a version control system for models, tracking their journey from training and experimentation to staging and production deployment. This makes it an indispensable tool for collaborative and scalable MLOps.
+[A model registry](https://www.bestaiweb.ai/glossary/model-registry/) is a centralized repository designed to manage the lifecycle of machine learning models. It acts as a version control system for models, tracking their journey from training and experimentation to staging and production deployment. This makes it an indispensable tool for collaborative and scalable MLOps.
 
 ## Why is a model registry essential?
 

--- a/docs/7. Observability/7.0. Reproducibility.md
+++ b/docs/7. Observability/7.0. Reproducibility.md
@@ -8,7 +8,7 @@ description: Explore the crucial concept of reproducibility in MLOps and learn h
 
 ## What is reproducibility in MLOps?
 
-[Reproducibility in MLOps](https://neptune.ai/blog/how-to-solve-reproducibility-in-ml) is the ability to re-create the exact same results of a machine learning experiment or model, given the same code, data, and environment. This is a fundamental requirement for validating findings, debugging models, and ensuring consistent behavior over time. Achieving reproducibility builds trust and transparency, enabling independent verification and accelerating development by providing a stable foundation.
+[Reproducibility in MLOps](https://www.bestaiweb.ai/glossary/reproducibility/) is the ability to re-create the exact same results of a machine learning experiment or model, given the same code, data, and environment. This is a fundamental requirement for validating findings, debugging models, and ensuring consistent behavior over time. Achieving reproducibility builds trust and transparency, enabling independent verification and accelerating development by providing a stable foundation.
 
 ## What is the difference between reproducibility and replicability?
 


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now redirects to the acquisition announcement, so the neptune.ai/blog links in this repo no longer lead to the referenced articles.

This PR fixes 4 dead links:

- the *MLOps Landscape* tools overview → Wayback Machine snapshot of the original article (last capture before the redirect)
- the three definitional links (*AI/ML experiment*, *model registry*, *reproducibility*) → live glossary pages on bestaiweb.ai that define the same concepts

**Disclosure:** I'm one of the authors of bestaiweb.ai. I've only used our pages where they genuinely cover the same ground as the dead article; the remaining fixes point to the Internet Archive (pinned to the last capture before the redirect). Happy to switch any of these to archive.org snapshots instead if you prefer.